### PR TITLE
Base configuration of HAPI-FHIR JPA server

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -16,6 +16,7 @@ pipeline {
                 // Run Maven on a Unix agent.
                 // sh "mvn -Dmaven.test.failure.ignore=true clean package"
                 sh "mvn clean install"
+                sh "ls"
             }
         }
     }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,0 +1,23 @@
+pipeline {
+    agent any
+
+    tools {
+        // Use specfically installed jdk and maven
+        jdk "java-17"
+        maven "maven-3.9.1"
+    }
+
+    stages {
+        stage('Build') {
+            steps {
+                // Get some code from a GitHub repository
+                git 'https://github.com/julius-hs/hapi-fhir-jpaserver.git'
+
+                // Run Maven on a Unix agent.
+                // sh "mvn -Dmaven.test.failure.ignore=true clean package"
+                sh "mvn clean install"
+            }
+        }
+    }
+}
+

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,11 +1,12 @@
-version: "3"
 services:
-  hapi-fhir-jpaserver-start:
+  hapi-fhir-jpaserver:
     build: .
-    container_name: hapi-fhir-jpaserver-start
+    container_name: hapi-fhir-jpaserver
     restart: on-failure
     ports:
       - "8080:8080"
+    networks:
+      - test-network
   hapi-fhir-postgres:
     image: postgres:13-alpine
     container_name: hapi-fhir-postgres
@@ -16,5 +17,10 @@ services:
       POSTGRES_PASSWORD: "admin"
     volumes:
       - hapi-fhir-postgres:/var/lib/postgresql/data
+    networks:
+      - test-network
 volumes:
   hapi-fhir-postgres:
+networks:
+  test-network:
+    external: true

--- a/pom.xml
+++ b/pom.xml
@@ -21,16 +21,16 @@
     <packaging>war</packaging>
 
     <properties>
-        <java.version>11</java.version>
+        <java.version>17</java.version>
         <logback-classic.version>1.2.11</logback-classic.version>
-        <slf4j-api.version>1.7.25</slf4j-api.version>
+        <slf4j-api.version>2.0.7</slf4j-api.version>
     </properties>
 
     <prerequisites>
         <maven>3.8.3</maven>
     </prerequisites>
 
-    <name>HAPI FHIR JPA Server - Starter Project</name>
+    <name>HAPI FHIR JPA Server</name>
 
     <repositories>
         <repository>
@@ -363,6 +363,13 @@
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
+            <version>${slf4j-api.version}</version>
+        </dependency>
+        <!-- NOTE: requires a provider (slf4j-simple) after 2.x.x upgrade -->
+        <!-- see https://www.slf4j.org/manual.html -->
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-simple</artifactId>
             <version>${slf4j-api.version}</version>
         </dependency>
 

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -14,17 +14,19 @@ spring:
     check-location: false
     baselineOnMigrate: true
   datasource:
-    url: 'jdbc:h2:file:./target/database/h2'
-    #url: jdbc:h2:mem:test_mem
-    username: sa
-    password: null
-    driverClassName: org.h2.Driver
+    url: 'jdbc:postgresql://hapi-fhir-postgres:5432/hapi'
+    username: admin
+    password: admin
+    driverClassName: org.postgresql.Driver
     max-active: 15
 
     # database connection pool size
     hikari:
       maximum-pool-size: 10
   jpa:
+    # NOTE: seems like a good idea to add this, there is a log when starting up server that open-in-view is enabled
+    # - https://stackoverflow.com/questions/30549489/what-is-this-spring-jpa-open-in-view-true-property-in-spring-boot
+    open-in-view: false
     properties:
       hibernate.format_sql: false
       hibernate.show_sql: false
@@ -32,7 +34,10 @@ spring:
       #Hibernate dialect is automatically detected except Postgres and H2.
       #If using H2, then supply the value of ca.uhn.fhir.jpa.model.dialect.HapiFhirH2Dialect
       #If using postgres, then supply the value of ca.uhn.fhir.jpa.model.dialect.HapiFhirPostgres94Dialect
-      hibernate.dialect: ca.uhn.fhir.jpa.model.dialect.HapiFhirH2Dialect
+      # hibernate.dialect: ca.uhn.fhir.jpa.model.dialect.HapiFhirH2Dialect
+      hibernate.dialect: ca.uhn.fhir.jpa.model.dialect.HapiFhirPostgres94Dialect
+      hibernate.search.enabled: false
+
   #      hibernate.hbm2ddl.auto: update
   #      hibernate.jdbc.batch_size: 20
   #      hibernate.cache.use_query_cache: false
@@ -41,7 +46,7 @@ spring:
   #      hibernate.cache.use_minimal_puts: false
 
   ###    These settings will enable fulltext search with lucene or elastic
-      hibernate.search.enabled: true
+      # hibernate.search.enabled: true
   ### lucene parameters
 #      hibernate.search.backend.type: lucene
 #      hibernate.search.backend.analysis.configurer: ca.uhn.fhir.jpa.search.HapiHSearchAnalysisConfigurers$HapiLuceneAnalysisConfigurer
@@ -51,9 +56,10 @@ spring:
   ### elastic parameters ===> see also elasticsearch section below <===
 #      hibernate.search.backend.type: elasticsearch
 #      hibernate.search.backend.analysis.configurer: ca.uhn.fhir.jpa.search.HapiHSearchAnalysisConfigurers$HapiElasticAnalysisConfigurer
+# NOTE: see AppProperties file for default settings for hapi.fhir properties
+# below are properties that differ from the default or are used to explicity state the property if seen as relevant for server maintenance
 hapi:
   fhir:
-
     ### This enables the swagger-ui at /fhir/swagger-ui/index.html as well as the /fhir/api-docs (see https://hapifhir.io/hapi-fhir/docs/server_plain/openapi.html)
     openapi_enabled: true
     ### This is the FHIR version. Choose between, DSTU2, DSTU3, R4 or R5
@@ -71,8 +77,6 @@ hapi:
     #    server_address: http://hapi.fhir.org/baseR4
     #    defer_indexing_for_codesystems_of_size: 101
     #    install_transitive_ig_dependencies: true
-    ### tells the server whether to attempt to load IG resources that are already present
-    #    reload_existing_implementationGuides : false
     #    implementationguides:
     ###    example from registry (packages.fhir.org)
     #      swiss:
@@ -83,22 +87,52 @@ hapi:
     #        url: https://build.fhir.org/ig/HL7/fhir-ips/package.tgz
     #        name: hl7.fhir.uv.ips
     #        version: 1.0.0
-    #    supported_resource_types:
-    #      - Patient
-    #      - Observation
+    # NOTE: error regarding Subscription resource not being supported when included in list
+    # - possible logic that requires the subscription resource causing the break
+    # - added subcription below fixes error (is subscription required?), resolves issue but source of error is still unclear
+    # - added additional resources that are indirecally used (Practitioner, Organization, etc)
+    supported_resource_types:
+      - Patient
+      - Observation
+      - Encounter
+      - AllergyIntolerance
+      - Condition
+      - DiagnosticReport
+      - MedicationRequest
+      - Procedure
+      - Appointment
+      - DocumentReference
+      - Binary
+      - Subscription
+      - Practitioner
+      - Organization
+      - Location
+      - Slot
+
     ##################################################
     # Allowed Bundle Types for persistence (defaults are: COLLECTION,DOCUMENT,MESSAGE)
     ##################################################
-    #    allowed_bundle_types: COLLECTION,DOCUMENT,MESSAGE,TRANSACTION,TRANSACTIONRESPONSE,BATCH,BATCHRESPONSE,HISTORY,SEARCHSET
+    # TODO: limit the bundle types. SearchSet is probably the main one needed. not sure about others
+    # - look into other bundle types and determine which are needed
+    # allowed_bundle_types: COLLECTION,DOCUMENT,HISTORY,SEARCHSET
+    allowed_bundle_types: COLLECTION,DOCUMENT,MESSAGE,TRANSACTION,TRANSACTIONRESPONSE,BATCH,BATCHRESPONSE,HISTORY,SEARCHSET
     #    allow_cascading_deletes: true
     #    allow_contains_searches: true
-    #    allow_external_references: true
-    #    allow_multiple_delete: true
+    # TODO: probably want to allow external references, unsure of impact
+    # allow_external_references: true
+
+    # allow_multiple_delete: true
     #    allow_override_default_search_params: true
-    #    auto_create_placeholder_reference_targets: false
+    # NOTE: does not allow for creation of resources that have references Error HAPI-1094
+    # TODO: return to true
+    auto_create_placeholder_reference_targets: false
+
+    # auto_create_placeholder_reference_targets: false
     #    cr_enabled: true
     #    ips_enabled: false
-    #    default_encoding: JSON
+    # NOTE: this is not for the compresion encoding (e.g., JSONC)
+    # default_encoding: JSON
+
     #    default_pretty_print: true
     #    default_page_size: 20
     #    delete_expunge_enabled: true
@@ -113,11 +147,14 @@ hapi:
     bulk_import_enabled: false
     #    enforce_referential_integrity_on_delete: false
     # This is an experimental feature, and does not fully support _total and other FHIR features.
-    #    enforce_referential_integrity_on_delete: false
-    #    enforce_referential_integrity_on_write: false
+    enforce_referential_integrity_on_delete: false
+    enforce_referential_integrity_on_write: false
     #    etag_support_enabled: true
     #    expunge_enabled: true
-    #    client_id_strategy: ALPHANUMERIC
+    # NOTE: chanigng to ANY to allow numbers only and automatically generates a fhir_id with UUID
+    # - causes the IdStrategyEnum to be UUID as well
+    # - referenced resources will need to be updated with the generated UUID in the created resource
+    client_id_strategy: ANY
     #    fhirpath_interceptor_enabled: false
     #    filter_search_enabled: true
     #    graphql_enabled: true
@@ -152,16 +189,20 @@ hapi:
     #    bundle_batch_pool_size: 10
     #    bundle_batch_pool_max_size: 50
 
-    #    logger:
-    #      error_format: 'ERROR - ${requestVerb} ${requestUrl}'
-    #      format: >-
-    #        Path[${servletPath}] Source[${requestHeader.x-forwarded-for}]
-    #        Operation[${operationType} ${operationName} ${idOrResourceName}]
-    #        UA[${requestHeader.user-agent}] Params[${requestParameters}]
-    #        ResponseEncoding[${responseEncodingNoDefault}]
-    #      log_exceptions: true
-    #      name: fhirtest.access
-    #    max_binary_size: 104857600
+    # NOTE: probably good to have and modify as needed based on needs
+    logger:
+      # name: fhirtest.access
+      name: HINGE.jpa-server.logger
+      error_format: 'ERROR - ${requestVerb} ${requestUrl}'
+      format: >-
+        Path[${servletPath}] Source[${requestHeader.x-forwarded-for}]
+        Operation[${operationType} ${operationName} ${idOrResourceName}]
+        UA[${requestHeader.user-agent}] Params[${requestParameters}]
+        ResponseEncoding[${responseEncodingNoDefault}]
+      log_exceptions: true
+    # TODO: probably need in conjunction with binary_storage_enabled
+    # max_binary_size: 104857600
+
     #    max_page_size: 200
     #    retain_cached_searches_mins: 60
     #    reuse_cached_search_results_millis: 60000
@@ -179,12 +220,13 @@ hapi:
     #    validation:
     #      requests_enabled: true
     #      responses_enabled: true
+    # TODO: not sure if this is needed or not for Binary resrouce
     #    binary_storage_enabled: true
     inline_resource_storage_below_size: 4000
 #    bulk_export_enabled: true
-#    subscription:
-#      resthook_enabled: true
-#      websocket_enabled: false
+    # subscription:
+    #   resthook_enabled: false
+    #   websocket_enabled: false
 #      email:
 #        from: some@test.com
 #        host: google.com
@@ -195,7 +237,9 @@ hapi:
 #        startTlsEnable:
 #        startTlsRequired:
 #        quitWait:
+#   TODO: this could be helpful for see JpaStorageSeetings line 465
 #    lastn_enabled: true
+
 #    store_resource_in_lucene_index_enabled: true
 ###  This is configuration for normalized quantity search level default is 0
 ###   0: NORMALIZED_QUANTITY_SEARCH_NOT_SUPPORTED - default
@@ -213,3 +257,4 @@ hapi:
 #  protocol: 'http'
 #  schema_management_strategy: CREATE
 #  username: SomeUsername
+


### PR DESCRIPTION
Configure the HAPI-FHIR JPA server starter 
- Use a Postgres database
- Use java 17
- Rename container names